### PR TITLE
Update Transaction.php

### DIFF
--- a/src/Rede/Transaction.php
+++ b/src/Rede/Transaction.php
@@ -382,7 +382,7 @@ class Transaction implements RedeSerializable, RedeUnserializable
                 'additional' => $this->additional
             ],
             function ($value) {
-                return !is_null($value);
+                return !empty($value);
             }
         );
     }


### PR DESCRIPTION
jsonSerialize - array_filter alterado o return de !is_null para !empty, pois a propriedade urls estava retornando com um array vazio e dava erro de "Urls: Required parameter missing (kind)." no request